### PR TITLE
Increased minimum Ansible version to 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - MOLECULEW_USE_SYSTEM=true
   matrix:
     # Spin off separate builds for each of the following versions of Ansible
-    - MOLECULEW_ANSIBLE=2.4.6
+    - MOLECULEW_ANSIBLE=2.5.10
     - MOLECULEW_ANSIBLE=2.7.0
 
 # Require the standard build environment

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GitHub.
 Requirements
 ------------
 
-* Ansible >= 2.4
+* Ansible >= 2.5
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing extensions for the atom.io editor.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports version 2.5 and earlier.