### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: Atom Packages
 ===========================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-atom-packages.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-atom-packages)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-atom-packages.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-atom-packages)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.atom--packages-blue.svg)](https://galaxy.ansible.com/gantsign/atom-packages)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-atom-packages/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.